### PR TITLE
Return env if it already exists

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -8,6 +8,9 @@ exports.mode = process.env.NODE_ENV || 'development';
 
 
 function env(name) {
+  if (exports[name]) {
+    return exports[name];
+  }
   reservedKeys.push(name);
   return exports[name] = setter();
 }


### PR DESCRIPTION
Saves complicated workarounds like:

``` javascript
var mode = process.env.NODE_ENV || 'development'
var env = (mode === 'production' || mode === 'development') ?
  browserify.settings[mode] : browserify.settings.env(mode)
env('transform', ['coffeeify'])
```

Now can just do:

``` javascript
var env = browserify.settings.env(process.env.NODE_ENV || 'development')
env('transform', ['coffeeify'])
```
