### PR TITLE
Implement dynamic caching

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -3,6 +3,7 @@ var uglify = require('uglify-js');
 var join = require('path').join;
 var zlib = require('zlib');
 var crypto = require('crypto');
+var fs = require('fs');
 
 function minify(str) {
   return uglify.minify(str, {fromString: str});
@@ -19,9 +20,54 @@ function bundleModule(modules, options) {
   return b;
 }
 
-function compile(path, options, cb) {
+var dynamicCache = {};
+var dynamicCacheTime = {};
+var dynamicCacheCallbacks = [];
+function updateDynamicCache(callback) {
+  var cached = Object.keys(dynamicCacheTime);
+  var remaining = cached.length;
+  if (0 === remaining) {
+    return callback()
+  }
+  if (dynamicCacheCallbacks.length) {
+    return dynamicCacheCallbacks.push(callback)
+  }
+  dynamicCacheCallbacks.push(callback)
+  cached.forEach(function (file) {
+    if (!(file in dynamicCache)) return;
+    fs.stat(file, function (err, stats) {
+      if (err || stats.mtime.getTime() !== dynamicCacheTime[file]) {
+        if (file in dynamicCache) {
+          delete dynamicCache[file];
+        }
+        if (file in dynamicCacheTime) {
+          delete dynamicCacheTime[file];
+        }
+      }
+      if (0 === --remaining) {
+        for (var i = 0; i < dynamicCacheCallbacks.length; i++) {
+          dynamicCacheCallbacks[i]();
+        }
+        dynamicCacheCallbacks = [];
+      }
+    })
+  });
+}
+function compile(path, options, cb, cacheUpdated) {
   cb = guard(cb);
+  if (options.cache === 'dynamic' && !cacheUpdated) {
+    updateDynamicCache(function () { compile(path, options, cb, true) })
+  }
   var b = Array.isArray(path) ? bundleModule(path, options) : bundleFile(path, options);
+  if (options.cache === 'dynamic') {
+    b.on('dep', function (dep) {
+      fs.stat(dep.id, function (err, stats) {
+        if (err) return;
+        dynamicCache[dep.id] = dep
+        dynamicCacheTime[dep.id] = stats.mtime.getTime()
+      })
+    })
+  }
   for (var i = 0; i < (options.external || []).length; i++) {
     b.external(options.external[i]);
   }
@@ -36,7 +82,8 @@ function compile(path, options, cb) {
     detectGlobals: options.detectGlobals,
     ignoreMissing: options.ignoreMissing,
     debug: options.debug,
-    standalone: options.standalone || false
+    standalone: options.standalone || false,
+    cache: (options.cache === 'dynamic' ? dynamicCache : {})
   }, (function (err, src) {
     if (err) return cb(err);
     if (options.minify) {
@@ -61,7 +108,7 @@ var zipCache = {};
 var tagCache = {};
 
 function cachedCompile(path, options, cb) {
-  if (!options.cache) return compile(path, options, cb);
+  if (!options.cache || options.cache === 'dynamic') return compile(path, options, cb);
   var cacheKey = JSON.stringify(path);
   if (cache[cacheKey]) {
     return cb(null, cache[cacheKey], zipCache[cacheKey], tagCache[cacheKey]);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -56,7 +56,7 @@ production.gzip = true;
 production.debug = false;
 
 var development = exports.env('development');
-development.cache = false;
+development.cache = 'dynamic';
 development.minify = false;
 development.gzip = false;
 development.debug = true;
@@ -82,7 +82,9 @@ function normalize(options) {
     });
 
 
-  if (typeof options.cache === 'string' && ms(options.cache)) {
+  if (options.cache === 'dynamic') {
+    // leave unchanged
+  } else if (typeof options.cache === 'string' && ms(options.cache)) {
     options.cache = 'public, max-age=' + Math.floor(ms(options.cache)/1000);
   } else if (options.cache === true) {
     options.cache = 'public, max-age=60';

--- a/test/index.js
+++ b/test/index.js
@@ -32,7 +32,7 @@ app.use('/file/jqparse.js', browserify('./directory/jquery.min.js', {cache: fals
 app.use('/file/jqnoparse.js', browserify('./directory/jquery.min.js', {cache: false, gzip: false, minify: false, debug: false, noParse: ['./directory/jquery.min.js']}))
 
 app.use('/file/beep.js', browserify('./directory/beep.js', {
-  cache: false,
+  cache: 'dynamic',
   gzip: false,
   minify: false,
   debug: true
@@ -44,7 +44,7 @@ app.use('/opt/file/beep.js', browserify('./directory/beep.js', {
   debug: false
 }));
 app.use('/file/boop.js', browserify('./directory/boop.js', {
-  cache: false,
+  cache: 'dynamic',
   gzip: false,
   minify: false,
   debug: true
@@ -56,7 +56,7 @@ app.use('/opt/file/boop.js', browserify('./directory/boop.js', {
   debug: false
 }));
 app.use('/syntax-error.js', browserify('./directory/syntax-error.js', {
-  cache: false,
+  cache: 'dynamic',
   gzip: false,
   minify: false,
   debug: true
@@ -69,7 +69,7 @@ app.use('/opt/syntax-error.js', browserify('./directory/syntax-error.js', {
 }));
 
 app.use('/dir', browserify('./directory', {
-  cache: false,
+  cache: 'dynamic',
   gzip: false,
   minify: false,
   debug: true
@@ -82,7 +82,7 @@ app.use('/opt/dir', browserify('./directory', {
 }));
 
 app.use('/mod.js', browserify(['require-test'], {
-  cache: false,
+  cache: 'dynamic',
   gzip: false,
   minify: false,
   debug: true,

--- a/test/settings.js
+++ b/test/settings.js
@@ -5,9 +5,9 @@ var equal = require('assert').equal;
 describe('settings', function () {
   describe('.cache', function () {
     describe('default development', function () {
-      it('is `false`', function () {
+      it('is `"dynamic"`', function () {
         settings.mode = 'development';
-        equal(normalize().cache, false);
+        equal(normalize().cache, 'dynamic');
         settings.mode = 'development';
       });
     });


### PR DESCRIPTION
This adds a new cache option of `'dynamic'` which is now the default for development.  It speeds compilation by caching the parsed versions of each file and only updating them when the last modified times have changed.

Unlike most methods for doing this, it does not use a watch on the files, instead it polls all the files whenever a request is made in order to check the files are up to date.  On my computer this takes about 10ms per request for a fairly large number of files, so seems to be acceptably quick.  For applications that include large files like jQuery it can provide a 4 times speed up once the files have been cached.

If nobody has any issues with this by 2013-07-04T18:00:00Z I will merge this and release as v1.14.0.  If someone else code reviews it and gives it the all clear, I will release it straight away.
