### PR TITLE
Added support for CoffeeScript and LiveScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ transform = [];
 insertGlobals = false;
 detectGlobals = true;
 standalone = false;
+grep = /.js|.coffee|.ls/
 ```
 
 To update:
@@ -194,14 +195,15 @@ The remaining settings are all passed through to browserify, you should look at 
 - `options.insertGlobals` - set to true to always insert `process`, `global` etc. without analysing the AST for faster builds but larger bundles (Note that `options.minify` may cause the globals to be removed again anyway) (default: false)
 - `options.detectGlobals` - set to false to skip adding `process`, `global` etc.  Setting this to false may break more npm modules (default: true).
 - `options.noParse` - an array of module names that should not be parsed for `require` statements of node.js style globals, can speed up loading things like jQuery that are huge but never use `require`.
-- `options.standalone` - Generate a standalone build (in a [umd](https://github.com/ForbesLindesay/umd) wrapper) with this name, you probably don't want this.
+- `options.standalone` - generate a standalone build (in a [umd](https://github.com/ForbesLindesay/umd) wrapper) with this name, you probably don't want this.
+- `options.grep` - the regular expression, something like `/.js|.coffee|.ls/`, that a filename should pass to be served using browserify from a directory.
 
 You can optionally pass a single item instead of an array to any of the options that take an array.
 
 ## License
 
   MIT
-  
+
   If you find it useful, a payment via [gittip](https://www.gittip.com/ForbesLindesay) would be appreciated.
 
 ![viewcount](https://viewcount.jepso.com/count/ForbesLindesay/browserify-middleware.png)

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -3,13 +3,11 @@ var fs = require('fs');
 var send = require('./send');
 var normalize = require('./settings').normalize;
 
-var isJSON = /\.json$/;
-
 module.exports = directory;
 function directory(path, options) {
   options = normalize(options);
   return function (req, res, next) {
-    if (!isJSON.test(req.path)) {
+    if (options.grep.test(req.path)) {
       fs.stat(join(path, req.path), function (err, stat) {
         if (err || !stat.isFile()) return next();
         send(join(path, req.path), options, req, res, next);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -41,6 +41,7 @@ exports.insertGlobals = false;
 exports.detectGlobals = true;
 exports.standalone = false;
 exports.noParse = [];
+exports.grep = /.js|.coffee|.ls/;
 
 //set some safe defaults for
 //unknown environemnts


### PR DESCRIPTION
Instead of whitelisted extensions, aka .js|.ls|.coffee, use a blacklist. This allows the use of other languages then javascript to be served using browserify-middleware.
