### PR TITLE
Double compile

### DIFF
--- a/lib/send.js
+++ b/lib/send.js
@@ -58,7 +58,7 @@ function updateDynamicCache(callback) {
 function compile(path, options, cb, cacheUpdated) {
   cb = guard(cb);
   if (options.cache === 'dynamic' && !cacheUpdated) {
-    updateDynamicCache(function () { compile(path, options, cb, true) })
+    return updateDynamicCache(function () { compile(path, options, cb, true) })
   }
   var b = Array.isArray(path) ? bundleModule(path, options) : bundleFile(path, options);
   if (options.cache === 'dynamic') {


### PR DESCRIPTION
When dynamic caching is enabled, `compile` runs twice due to unintentional fallthrough.
