### PR TITLE
Fix noParse for bare module names

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function browserify(path, options) {
     var dir = directory();
     options = exports.settings.normalize(options);
     options.noParse = options.noParse.map(function (path) {
-      if (path[0] != '.') return //support `['jquery']` as well as `['./src/jquery.js']`
+      if (path[0] != '.') return path; //support `['jquery']` as well as `['./src/jquery.js']`
       if (resolve(path) === normalize(path)) {
         return normalize(path);
       } else {


### PR DESCRIPTION
This was mapping inputs like `['jquery']` to `[null]`.
