### PR TITLE
added support for options.extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The remaining settings are all passed through to browserify, you should look at 
 - `options.detectGlobals` - set to false to skip adding `process`, `global` etc.  Setting this to false may break more npm modules (default: true).
 - `options.noParse` - an array of module names that should not be parsed for `require` statements of node.js style globals, can speed up loading things like jQuery that are huge but never use `require`.
 - `options.standalone` - generate a standalone build (in a [umd](https://github.com/ForbesLindesay/umd) wrapper) with this name, you probably don't want this.
+- `options.extensions` - an array of optional extra extensions for the module lookup machinery to use when the extension has not been specified. By default browserify considers only `.js` and `.json` files in such cases.
 
 You can optionally pass a single item instead of an array to any of the options that take an array.
 

--- a/lib/send.js
+++ b/lib/send.js
@@ -12,7 +12,7 @@ function minify(str) {
 }
 
 function bundleFile(path, options) {
-  return browserify({entries: [path], noParse: options.noParse});
+  return browserify({entries: [path], noParse: options.noParse, extensions: options.extensions});
 }
 function bundleModule(modules, options) {
   var b = browserify({noParse: options.noParse});

--- a/test/directory/dep.weird
+++ b/test/directory/dep.weird
@@ -1,0 +1,1 @@
+console.log('this is a weird file to require');

--- a/test/directory/weirddep.js
+++ b/test/directory/weirddep.js
@@ -1,0 +1,1 @@
+require('./dep');

--- a/test/index.js
+++ b/test/index.js
@@ -67,6 +67,13 @@ app.use('/opt/syntax-error.js', browserify('./directory/syntax-error.js', {
   minify: true,
   debug: false
 }));
+app.use('/weirddep.js', browserify('./directory/weirddep.js', {
+  extensions: ['.weird']
+}));
+app.use('/opt/weirddep.js', browserify('./directory/weirddep.js', {
+  extensions: ['.weird'],
+  gzip: true
+}));
 
 app.use('/dir', browserify('./directory', {
   cache: 'dynamic',
@@ -301,6 +308,21 @@ function test(optimised, get, it) {
             }
           }
         });
+      });
+    });
+  });
+  describe('extensions', function () {
+    it('includes files required with weird extensions', function (done) {
+      get('/weirddep.js', optimised, function (err, res) {
+        if (err) return done(err);
+        vm.runInNewContext(res, {
+          console: {
+            log: function (txt) {
+              assert.equal(txt, 'this is a weird file to require');
+              done();
+            }
+          }
+        })
       });
     });
   });


### PR DESCRIPTION
From the browserify docs:

> `opts.extensions` is an array of optional extra extensions for the module lookup
> machinery to use when the extension has not been specified.
> By default browserify considers only `.js` and `.json` files in such cases.
