### PR TITLE
Split send.js into compile.js and send.js

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -162,4 +162,4 @@ function cachedCompile(path, options, cb) {
     });
   }
 }
-module.exports = {compile: compile, cachedCompile: cachedCompile}
+module.exports = cachedCompile

--- a/lib/send.js
+++ b/lib/send.js
@@ -1,4 +1,4 @@
-var cachedCompile = require('./compile').cachedCompile;
+var cachedCompile = require('./compile');
 var start = new Date().toUTCString();
 
 module.exports = function send(path, options, req, res, next) {


### PR DESCRIPTION
This is a minor change. Split send.js into send.js and compile.js, so that compile.js can be split into its own module in the future. 
