### PR TITLE
Fix dynamic cache

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -6,10 +6,9 @@ var zlib = require('zlib');
 var crypto = require('crypto');
 var fs = require('fs');
 
+var DynamicCache = require('./dynamic-cache.js');
 //START Compile
 var dynamicCache = {};
-var dynamicCacheTime = {};
-var dynamicCacheCallbacks = [];
 
 var cache = {};
 var zipCache = {};
@@ -32,37 +31,6 @@ function bundleModule(modules, options) {
     }
   }
   return b;
-}
-
-function updateDynamicCache(callback) {
-  var cached = Object.keys(dynamicCacheTime);
-  var remaining = cached.length;
-  if (0 === remaining) {
-    return callback()
-  }
-  if (dynamicCacheCallbacks.length) {
-    return dynamicCacheCallbacks.push(callback)
-  }
-  dynamicCacheCallbacks.push(callback)
-  cached.forEach(function (file) {
-    if (!(file in dynamicCache)) return;
-    fs.stat(file, function (err, stats) {
-      if (err || stats.mtime.getTime() !== dynamicCacheTime[file]) {
-        if (file in dynamicCache) {
-          delete dynamicCache[file];
-        }
-        if (file in dynamicCacheTime) {
-          delete dynamicCacheTime[file];
-        }
-      }
-      if (0 === --remaining) {
-        for (var i = 0; i < dynamicCacheCallbacks.length; i++) {
-          dynamicCacheCallbacks[i]();
-        }
-        dynamicCacheCallbacks = [];
-      }
-    })
-  });
 }
 
 function transformSourcesRelativeTo(source, basedir) {
@@ -103,17 +71,19 @@ function guard(fn) {
 
 function compile(path, options, cb, cacheUpdated) {
   cb = guard(cb);
-  if (options.cache === 'dynamic' && !cacheUpdated) {
-    return updateDynamicCache(function () { compile(path, options, cb, true) })
+  var cache;
+  if (options.cache === 'dynamic') {
+    cache = dynamicCache[path + ':' + options.external + ':' + options.debug];
+    if (cache && !cacheUpdated) {
+      return cache.update(function () { compile(path, options, cb, true) });
+    } else if (!cache) {
+      cache = (dynamicCache[path + ':' + options.external + ':' + options.debug] = new DynamicCache());
+    }
   }
   var b = Array.isArray(path) ? bundleModule(path, options) : bundleFile(path, options);
   if (options.cache === 'dynamic') {
     b.on('dep', function (dep) {
-      fs.stat(dep.id, function (err, stats) {
-        if (err) return;
-        dynamicCache[dep.id] = dep
-        dynamicCacheTime[dep.id] = stats.mtime.getTime()
-      })
+      cache.add(dep);
     })
   }
   for (var i = 0; i < (options.external || []).length; i++) {
@@ -131,7 +101,7 @@ function compile(path, options, cb, cacheUpdated) {
     ignoreMissing: options.ignoreMissing,
     debug: options.debug,
     standalone: options.standalone || false,
-    cache: (options.cache === 'dynamic' ? dynamicCache : {})
+    cache: (options.cache === 'dynamic' ? cache.getCache() : {})
   }, (function (err, src) {
     if (err) return cb(err);
     if (options.debug) {

--- a/lib/dynamic-cache.js
+++ b/lib/dynamic-cache.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var fs = require('fs');
+
+module.exports = DynamicCache;
+
+function DynamicCache() {
+  this._queue = [];
+  this._cache = {};
+  this._time = {};
+}
+
+DynamicCache.prototype.update = function (cb) {
+  var cached = Object.keys(this._time);
+  var remaining = cached.length;
+  if (remaining === 0) return cb();
+  if (this._queue.length) return this._queue.push(cb);
+  this._queue.push(cb);
+  var endOne = function () {
+    if (0 === --remaining) {
+      for (var i = 0; i < this._queue.length; i++) {
+        this._queue[i]();
+      }
+      this._queue = [];
+    }
+  }.bind(this);
+  cached.forEach(function (file) {
+    if (!(file in this._cache)) return endOne();
+    fs.stat(file, function (err, stats) {
+      if (err || stats.mtime.getTime() !== this._time[file]) {
+        if (file in this._cache) {
+          delete this._cache[file];
+        }
+        if (file in this._time) {
+          delete this._time[file];
+        }
+      }
+      endOne();
+    }.bind(this))
+  }.bind(this));
+};
+
+DynamicCache.prototype.add = function (dep) {
+  fs.stat(dep.id, function (err, stats) {
+    if (err) return;
+    this._cache[dep.id] = dep
+    this._time[dep.id] = stats.mtime.getTime()
+  }.bind(this))
+};
+
+DynamicCache.prototype.getCache = function () {
+  return this._cache;
+};


### PR DESCRIPTION
This fixes dynamic cache by having one dynamic cache per `[path + options.external + options.debug]` combo.

It would be great if someone could review this before I merge it and make sure it looks like I haven't made too many hopeless mistakes.  It would also be good to sort out a test case if I get time.
