### PR TITLE
Add a `precompile` option without directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Production defaults:
 
 ```javascript
 production.cache = true; // equivalent to "public, max-age=60"
+production.precompile = true;
 production.minify = true;
 production.gzip = true;
 production.debug = false;
@@ -111,6 +112,7 @@ Development defaults:
 
 ```javascript
 development.cache = false;
+development.precompile = false;
 development.minify = false;
 development.gzip = false;
 development.debug = true;
@@ -175,6 +177,26 @@ If cache is an `object` of the form `{private: true || false, maxAge: '10 minute
 If cache is any other `string` it will be sent directly to the client.
 
 **N.B.** that if caching is enabled, the server never times out its cache, no matter what the timeout set for the client.
+
+#### precompile
+
+The precompile setting enables bundles to be precompiled/built and readily cached immediately on server startup. This option is not available when using browserify with a directory.  If `precompile` is set to `true`, the bundle will be compiled & cached at server start.
+
+```javascript
+// Precompile a browserified file at a path
+app.get('/js/file.js', browserify('./client/file.js', {
+  cache: true,
+  precompile: true
+}));
+
+// Precompile a bundle exposing `require` for a few npm packages.
+app.get('/js/bundle.js', browserify(['hyperquest', 'concat-stream'], {
+  cache: true,
+  precompile: true
+}));
+```
+
+**N.B.**  It only makes sense to use precompiling when caching is enabled. If caching is disabled, no precompiling will happen.
 
 #### minify
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,9 +1,13 @@
 var send = require('./send');
+var cachedCompile = require('./compile');
 var normalize = require('./settings').normalize;
 
 module.exports = directory;
 function directory(path, options) {
   options = normalize(options);
+  if (options.precompile) {
+    cachedCompile(path, options, function () {});
+  }
   return function (req, res, next) {
     send(path, options, req, res, next);
   };

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -1,4 +1,5 @@
 var send = require('./send');
+var cachedCompile = require('./compile');
 var normalize = require('./settings').normalize;
 
 module.exports = modules;
@@ -9,6 +10,9 @@ function modules(modules, options) {
       .filter(function (name) {
         return modules.indexOf(name) === -1;
       });
+  }
+  if (options.precompile) {
+    cachedCompile(path, options, function () {});
   }
   return function (req, res, next) {
     send(modules, options, req, res, next);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -54,12 +54,14 @@ exports.debug = false;
 
 var production = exports.env('production');
 production.cache = true;
+production.precompile = true;
 production.minify = true;
 production.gzip = true;
 production.debug = false;
 
 var development = exports.env('development');
 development.cache = 'dynamic';
+development.precompile = false;
 development.minify = false;
 development.gzip = false;
 development.debug = true;
@@ -98,6 +100,7 @@ function normalize(options) {
                   + Math.floor(ms(options.cache.maxAge.toString())/1000);
   }
 
+  options.precompile = !!options.precompile;
   options.external = arrayify(options.external);
   options.ignore = arrayify(options.ignore);
   options.transform = arrayify(options.transform);

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,7 @@ app.use('/file/beep.js', browserify('./directory/beep.js', {
 }));
 app.use('/opt/file/beep.js', browserify('./directory/beep.js', {
   cache: true,
+  precompile: true,
   gzip: true,
   minify: true,
   debug: false


### PR DESCRIPTION
All credit should go to @bjoerge for the original code in #33 

I decided to remove directory support for the precompile option as I'm still not happy with how that works.  At least with this it can still work fine providing you use it on individual files.
