### PR TITLE
Passing options to transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,10 @@ The remaining settings are all passed through to browserify, you should look at 
 - `options.external` - an array of module names that will be required from external bundles (see [browserify/multiple bundles](https://github.com/substack/node-browserify#multiple-bundles)) (default: `[]`)
 - `options.ignore` - an aray of module names that are prevented from showing up in the output bundle (default: `[]`)
 - `options.ignoreMissing` - set to `true` to ignore errors when a module can't be found (default: `false`).
-- `options.transform` - an array of strings or functions to transform top level modules (default: `[]`).
+- `options.transform` - an array of transforms to transform top level modules (default: `[]`). Each item can be:
+    - `"transform-name"` - the npm name of the transform
+    - `transformFunction` - the transform function
+    - `["transform-name" | tranformFunction, {option1: true, ...}]` - the transform and some options
 - `options.insertGlobals` - set to true to always insert `process`, `global` etc. without analysing the AST for faster builds but larger bundles (Note that `options.minify` may cause the globals to be removed again anyway) (default: false)
 - `options.detectGlobals` - set to false to skip adding `process`, `global` etc.  Setting this to false may break more npm modules (default: true).
 - `options.noParse` - an array of module names that should not be parsed for `require` statements of node.js style globals, can speed up loading things like jQuery that are huge but never use `require`.

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -93,7 +93,13 @@ function compile(path, options, cb, cacheUpdated) {
     b.ignore(options.ignore[i]);
   }
   for (var i = 0; i < (options.transform || []).length; i++) {
-    b.transform(options.transform[i]);
+    var transform = options.transform[i];
+
+    if (transform instanceof Array) {
+      b.transform(transform[1], transform[0]);
+    } else {
+      b.transform(transform);
+    }
   }
   b.bundle({
     insertGlobals: options.insertGlobals,


### PR DESCRIPTION
Some transforms allow options to be passed to them, and this is supported in browserify command line and API, and now in browserify-middlware.

See readme for docs.

```
transform: [["transform", {option1: true, ...}], "other-transform"]
```
