### PR TITLE
Async support for hooks

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -5,6 +5,7 @@ var relative = require('path').relative;
 var zlib = require('zlib');
 var crypto = require('crypto');
 var fs = require('fs');
+var async = require('async');
 
 var DynamicCache = require('./dynamic-cache.js');
 //START Compile
@@ -104,28 +105,61 @@ function compile(path, options, cb, cacheUpdated) {
     cache: (options.cache === 'dynamic' ? cache.getCache() : {})
   }, (function (err, src) {
     if (err) return cb(err);
-    if (options.postcompile) src = options.postcompile(src);
-    if (options.debug) {
-      if (options.basedir) {
-        src = transformSourcesRelativeTo(src, options.basedir);
+
+    function safeHook(hook) {
+      if ('function' !== typeof hook) return function(src, cb) { cb(null, src); };
+      return function(src, cb) {
+        var returnSrc = hook(src, function(err, callbackSrc) {
+          if(err) return cb(err);
+          if('string' == typeof returnSrc) return; // src was already returned in returnSrc.
+          cb(null, callbackSrc);
+        });
+        if('string' == typeof returnSrc) { // Function returned a string, use that instead of callback
+          cb(null, returnSrc);
+        }
       }
-      src = unixifySourceMap(src);
     }
-    if (options.minify) {
-      if (options.preminify) src = options.preminify(src);
-      try {
-        src = minify(src, options.minify).code;
-      } catch (ex) { } //better to just let the client fail to parse
-      if (options.postminify) src = options.postminify(src);
-    }
-    if (options.gzip) {
-      zlib.gzip(src, function (err, res) {
-        if (err) return cb(err);
-        cb(null, new Buffer(src), res, md5(src));
-      });
-    } else {
-      cb(null, new Buffer(src), null, md5(src));
-    }
+
+    var
+      postcompile = safeHook(options.postcompile),
+      preminify = safeHook(options.preminify),
+      postminify = safeHook(options.postminify);
+
+    async.waterfall([
+      function(cb) { 
+        postcompile(src, cb); },
+      function(src, cb) {
+        if (!options.debug) return cb(null, src);
+        if (options.basedir) {
+          src = transformSourcesRelativeTo(src, options.basedir);
+        }
+        src = unixifySourceMap(src);
+        cb(null, src);
+      },
+      function(src, cb) {
+        if (!options.minify) return cb(null, src);
+        async.waterfall([
+          function(cb) { preminify(src, cb); },
+          function(src, cb) {
+            try {
+              src = minify(src, options.minify).code;
+            } catch (ex) { } //better to just let the client fail to parse
+            cb(null, src);
+          },
+          function(src, cb) { postminify(src, cb); }
+        ], cb);
+      }
+    ], function(err, src) {
+      if (err) return cb(err);
+      if (options.gzip) {
+        zlib.gzip(src, function (err, res) {
+          if (err) return cb(err);
+          cb(null, new Buffer(src), res, md5(src));
+        });
+      } else {
+        cb(null, new Buffer(src), null, md5(src));
+      }
+    });
   }));
 }
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -126,8 +126,7 @@ function compile(path, options, cb, cacheUpdated) {
       postminify = safeHook(options.postminify);
 
     async.waterfall([
-      function(cb) { 
-        postcompile(src, cb); },
+      function(cb) { postcompile(src, cb); },
       function(src, cb) {
         if (!options.debug) return cb(null, src);
         if (options.basedir) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "express": "*"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "browserify": "~4.2.1",
     "uglify-js": "~2.4.15",
     "ms": "~0.6.2",


### PR DESCRIPTION
Hi, I propose this update to the hooks system to support async style hooks. I've made it backwards compatible to sync hooks by checking if the return value is a string. There are perhaps slightly more optimal ways of doing this, but this passes all the tests.

I used this to integrate closure compiler with the postcompile hook.