### PR TITLE
add in plugin support

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -66,6 +66,13 @@ function compile(path, options, cb, cacheUpdated) {
     standalone: options.standalone || false,
     cache: cache ? cache.getCache() : undefined
   });
+  if (options.plugins) {
+    var plugins = options.plugins; // in the format options.plugins = [{plugin: plugin, options: options}, {plugin: plugin, options: options}, ... ]
+    for(var i = 0; i < plugins.length; i++) {
+      var obj = plugins[i];
+      b.plugin(obj.plugin, obj.options);
+    }
+  }
   if (Array.isArray(path)) {
     for (var i = 0; i < path.length; i++) {
       if (typeof path[i] === 'object') { // obj spec support; i.e. {"jquery": {options...}}

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -70,7 +70,7 @@ function compile(path, options, cb, cacheUpdated) {
     var plugins = options.plugins; // in the format options.plugins = [{plugin: plugin, options: options}, {plugin: plugin, options: options}, ... ]
     for(var i = 0; i < plugins.length; i++) {
       var obj = plugins[i];
-      b.plugin(obj.plugin, obj.options);
+      bundle.plugin(obj.plugin, obj.options);
     }
   }
   if (Array.isArray(path)) {


### PR DESCRIPTION
It's nice that browserify-middleware supports transform options and everything, but sometimes you need something more extreme, like plugin support.  This tiny fix allows one to pass in an array of plugins to the initial set of options so that they can manipulate the actual browserify object.

Browserify offers an official plugin api, but there is no way to access the browserify instance from the middleware as the compile step hides the instance variable in a closure.  Plugins should only be applied after the options for browserify have been processed.