### PR TITLE
Basedir and run options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ app.get('/js/file.js', browserify('./client/file.js'));
 //provide a bundle exposing `require` for a few npm packages.
 app.get('/js/bundle.js', browserify(['hyperquest', 'concat-stream']));
 
+//provide a bundle for a few npm packages plus run main.js
+app.get('/js/bundle.js', browserify(['hyperquest', 'concat-stream', {'./client/main.js': {run: true}]}));
+
 app.listen(3000);
 ```
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -62,6 +62,7 @@ function compile(path, options, cb, cacheUpdated) {
     insertGlobals: options.insertGlobals,
     detectGlobals: options.detectGlobals,
     ignoreMissing: options.ignoreMissing,
+    basedir: options.basedir,
     debug: options.debug,
     standalone: options.standalone || false,
     cache: cache ? cache.getCache() : undefined

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -75,7 +75,11 @@ function compile(path, options, cb, cacheUpdated) {
         keys.forEach(function (key) {
           console.dir(key);
           console.dir(spec[key]);
-          bundle.require(key, spec[key]);
+          if (spec[key].run) {
+            bundle.add(key, spec[key]);
+          } else {
+            bundle.require(key, spec[key]);
+          }
         })
       } else {
         bundle.require(path[i]);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -42,7 +42,7 @@ exports.detectGlobals = true;
 exports.standalone = false;
 exports.noParse = [];
 exports.extensions = [];
-exports.basedir = false;
+exports.basedir = undefined;
 exports.grep = /\.js$/;
 
 //set some safe defaults for


### PR DESCRIPTION
There's two improvements in this pull request:

1) it allows the browserify `basedir` option to be passed through the middleware.

We have an application where the browserify-middleware is in one package and the things to be browserified are in multiple other packages. With this fix browserify uses the correct base path.

2) The `run` option allows to intersperse bundles with files to be added via `bundle.add` together with files that are bundled with `bundle.require`.

This option is helpful/we need because we have a global bundle with just exports and then page-specific bundles, which have modules inside by themselves but also a kickstart file that should be started with the bundle. Otherwise it would require another external file just for the kickstart.

Any thoughts on these? Any chance of getting them included?