### PR TITLE
Options can sometimes be booleans

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -111,7 +111,7 @@ function normalize(options) {
 }
 
 function arrayify(val) {
-  if (val && !Array.isArray(val)) {
+  if (val && !Array.isArray(val) && typeof val !== 'boolean') {
     return [val];
   } else {
     return val;


### PR DESCRIPTION
Browserify allows some options, like `noParse` to be booleans. This patch makes sure that if you pass a boolean option, it isn't wrapped in an array (which would make no sense anyway). 

Fixes #69
