### PR TITLE
Fix dynamic caching to prevent rebuilding the whole bundle on every load

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -81,8 +81,6 @@ function compile(path, options, cb, cacheUpdated) {
         var spec = path[i];
         var keys = Object.keys(spec);
         keys.forEach(function (key) {
-          console.dir(key);
-          console.dir(spec[key]);
           if (spec[key].run) {
             bundle.add(key, spec[key]);
           } else {

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -65,7 +65,8 @@ function compile(path, options, cb, cacheUpdated) {
     basedir: options.basedir,
     debug: options.debug,
     standalone: options.standalone || false,
-    cache: cache ? cache.getCache() : undefined
+    cache: cache ? cache.getCache() : undefined,
+    fullPaths: cache ? true : false
   });
   if (options.plugins) {
     var plugins = options.plugins; // in the format options.plugins = [{plugin: plugin, options: options}, {plugin: plugin, options: options}, ... ]

--- a/lib/dynamic-cache.js
+++ b/lib/dynamic-cache.js
@@ -39,8 +39,9 @@ DynamicCache.prototype.update = function (cb) {
       if (err || stats.mtime.getTime() !== this._time[filename]) {
         var deps = getDeps(filename);
         for (var i = 0; i < deps.length; i++) {
-          if (this._cache[deps]) {
-            delete this._cache[deps];
+          var dep = deps[i];
+          if (this._cache[dep]) {
+            delete this._cache[dep];
           }
         }
         if (filename in this._files) {
@@ -59,11 +60,19 @@ DynamicCache.prototype.populate = function (bundle) {
   this._files = {};
   this._time = {};
 
+  var getDeps = function (dep) {
+    var deps = [];
+    for (var key in dep.deps) {
+      deps.push(dep.deps[key]);
+    }
+    return deps;
+  }
+
   bundle.on('dep', function (dep) {
     fs.stat(dep.file, function (err, stats) {
       if (err) return;
       this._cache[dep.id] = dep;
-      this._files[dep.file] = (this._files[dep.file] || []).concat(dep.id);
+      this._files[dep.file] = getDeps(dep);
       this._time[dep.file] = stats.mtime.getTime();
     }.bind(this));
   }.bind(this));
@@ -72,7 +81,7 @@ DynamicCache.prototype.populate = function (bundle) {
     tr.on('file', function (dependency) {
       fs.stat(dependency, function (err, stats) {
         if (err) return;
-        this._files[dependency] = (this._files[dependency] || []).concat(file);
+        this._files[dependency] = getDeps(dependency);
         this._time[dependency] = stats.mtime.getTime();
       }.bind(this));
     }.bind(this));


### PR DESCRIPTION
This should fix https://github.com/ForbesLindesay/browserify-middleware/issues/72 and https://github.com/ForbesLindesay/browserify-middleware/issues/68