### PR TITLE
Upgrade browserify to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "require-test": "1.0.0"
   },
   "dependencies": {
-    "browserify": "^8.1.3",
+    "browserify": "^9.0.3",
     "mold-source-map": "0.3.0",
     "ms": "^0.7.0",
     "once": "^1.3.1",


### PR DESCRIPTION
Hi there, awesome job with this wrapper. Can you please upgrade browserify to latest? Thanks.
There seems to be a bug that my whole absolute path to script is exposed to the output which contains folder names, OS specific and usernames. This is not ideal because I want to keep it generic.

I think it's related to https://github.com/substack/node-browserify/issues/675