### PR TITLE
Fix caching

### DIFF
--- a/lib/dynamic-cache.js
+++ b/lib/dynamic-cache.js
@@ -37,15 +37,31 @@ DynamicCache.prototype.update = function (cb) {
       this._queue = [];
     }
   }.bind(this);
+
   var getDeps = function (filename) {
-    if (this._files[filename]) {
-      return [[filename]].concat(this._files[filename].map(getDeps)).reduce(function (a, b) {
-        return a.concat(b);
-      });
-    } else {
-      return [filename];
+    var dependencies = this._files[filename];
+    var dependenciesSet = {};
+
+    dependenciesSet[filename] = true;
+
+    var getSubDeps = function(deps){
+      deps.forEach(function (dep, index) {
+        if (!dependenciesSet[dep]) {
+          dependenciesSet[dep] = true;
+          var subDeps = this._files[deps[index]];
+          if (subDeps){
+            getSubDeps(subDeps);
+          }
+        }
+      }, this);
+    }.bind(this)
+
+    if (dependencies) {
+      getSubDeps(dependencies);
     }
+    return Object.keys(dependenciesSet);
   }.bind(this);
+
   files.forEach(function (filename) {
     fs.stat(filename, function (err, stats) {
       if (err || stats.mtime.getTime() !== this._time[filename]) {

--- a/lib/dynamic-cache.js
+++ b/lib/dynamic-cache.js
@@ -3,13 +3,15 @@
 var fs = require('fs');
 
 function objectValues(obj) {
-  if (typeof obj !== 'object') {
-    return [];
+  var values = [];
+  if (typeof obj === 'object') {
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        values.push(obj[key]);
+      }
+    }
   }
-
-  return Object.keys(obj).map(function (key) {
-    return obj[key];
-  });
+  return values
 }
 
 module.exports = DynamicCache;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "require-test": "1.0.0"
   },
   "dependencies": {
-    "browserify": "^8.1.3",
+    "browserify": "^9.0.8",
     "mold-source-map": "0.3.0",
     "ms": "^0.7.0",
     "once": "^1.3.1",


### PR DESCRIPTION
We had a large dependency tree and it crashed everytime with stackoverflow error.
This was because of too many recursive calls of `getDeps`.
Also the whole method seemed to be pretty broken and did not return the correct dependencies.