### PR TITLE
Remove references to defunct `precompile` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ Production defaults:
 
 ```javascript
 production.cache = true; // equivalent to "public, max-age=60"
-production.precompile = true;
 production.minify = true;
 production.gzip = true;
 production.debug = false;
@@ -116,7 +115,6 @@ Development defaults:
 
 ```javascript
 development.cache = 'dynamic';
-development.precompile = false;
 development.minify = false;
 development.gzip = false;
 development.debug = true;
@@ -181,26 +179,6 @@ If cache is an `object` of the form `{private: true || false, maxAge: '10 minute
 If cache is any other `string` it will be sent directly to the client.
 
 **N.B.** that if caching is enabled, the server never times out its cache, no matter what the timeout set for the client.
-
-#### precompile
-
-The precompile setting enables bundles to be precompiled/built and readily cached immediately on server startup. This option is not available when using browserify with a directory.  If `precompile` is set to `true`, the bundle will be compiled & cached at server start.
-
-```javascript
-// Precompile a browserified file at a path
-app.get('/js/file.js', browserify('./client/file.js', {
-  cache: true,
-  precompile: true
-}));
-
-// Precompile a bundle exposing `require` for a few npm packages.
-app.get('/js/bundle.js', browserify(['hyperquest', 'concat-stream'], {
-  cache: true,
-  precompile: true
-}));
-```
-
-**N.B.**  It only makes sense to use precompiling when caching is enabled. If caching is disabled, no precompiling will happen.
 
 #### minify
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -54,14 +54,12 @@ exports.debug = false;
 
 var production = exports.env('production');
 production.cache = true;
-production.precompile = true;
 production.minify = true;
 production.gzip = true;
 production.debug = false;
 
 var development = exports.env('development');
 development.cache = 'dynamic';
-development.precompile = false;
 development.minify = false;
 development.gzip = false;
 development.debug = true;
@@ -100,7 +98,6 @@ function normalize(options) {
                   + Math.floor(ms(options.cache.maxAge.toString())/1000);
   }
 
-  options.precompile = !!options.precompile;
   options.external = arrayify(options.external);
   options.ignore = arrayify(options.ignore);
   options.transform = arrayify(options.transform);

--- a/test/index.js
+++ b/test/index.js
@@ -49,7 +49,6 @@ app.use('/file/beep.js', browserify(__dirname + '/directory/beep.js', {
 }));
 app.use('/opt/file/beep.js', browserify(__dirname + '/directory/beep.js', {
   cache: true,
-  precompile: true,
   gzip: true,
   minify: true,
   debug: false
@@ -108,7 +107,6 @@ app.use('/mod.js', browserify(['require-test'], {
 }));
 app.use('/opt/mod.js', browserify(['require-test'], {
   cache: true,
-  precompile: true,
   gzip: true,
   minify: true,
   debug: false,

--- a/test/settings.js
+++ b/test/settings.js
@@ -163,8 +163,7 @@ describe('settings', function () {
         cache: false,
         minify: false,
         gzip: true,
-        debug: false,
-        precompile: false
+        debug: false
       });
       settings.mode = 'development';
     });


### PR DESCRIPTION
This PR removes all references to the `precompile` option as it does nothing anymore.

I got pretty confused today by reading the documentation and then browsing the source code trying to figure out how the precompilation was working. Turns out the option was removed a while ago (as referenced in #78) in favour of it being always-on. 