### PR TITLE
Make watchify ignore node_modules by default

### DIFF
--- a/lib/build-response.js
+++ b/lib/build-response.js
@@ -18,7 +18,7 @@ module.exports = function send(path, options) {
   } else if (options.cache === 'dynamic') {
     var response, resolve;
     var updatingTimeout;
-    bundle = watchify(bundle, {poll: true, delay: 0});
+    bundle = watchify(bundle, {poll: true, delay: 0, ignoreWatch: true});
     bundle.on('update', function () {
       if (resolve) {
         clearTimeout(updatingTimeout);


### PR DESCRIPTION
For any project with more than a few dependencies polling on the node_modules directory requires a lot of cpu (nearly 100% in my vm). Adding `ignoreWatch: true` to watchify's options to enable the following ignore pattern: `ignoreWatch: ['**/node_modules/**']` seems like a more sane default. This drastically reduces CPU usage when polling is enabled.

Related to #96, but doesn't directly fix it.