### PR TITLE
Added support for browserify 'paths'

### DIFF
--- a/lib/build-bundle.js
+++ b/lib/build-bundle.js
@@ -12,6 +12,7 @@ function compile(path, options) {
     ignoreMissing: options.ignoreMissing,
     bundleExternal: options.bundleExternal,
     basedir: options.basedir,
+    paths: options.paths,
     debug: options.debug,
     standalone: options.standalone || false,
     cache: options.cache === 'dynamic' ? {} : undefined,


### PR DESCRIPTION
This PR adds a simple translation between a new browserify-middleware option `paths` into the browserify parameter `paths`. This was necessary with my project due having a different relative paths implementation. See:

https://github.com/vigetlabs/gulp-starter/issues/17

Would love to get this merged soon! 